### PR TITLE
Allow for authenticated requests without specific classes

### DIFF
--- a/src/Lift.php
+++ b/src/Lift.php
@@ -158,6 +158,16 @@ class Lift
     }
 
     /**
+     * Gets the Authenticated Client
+     *
+     * @return \GuzzleHttp\ClientInterface Authenticated client
+     */
+    public function getAuthenticatedClient()
+    {
+        return $this->authenticatedClient;
+    }
+
+    /**
      * Get the Account Manager.
      *
      * @return \Acquia\LiftClient\Manager\AccountManager


### PR DESCRIPTION
This allows for code like this:

```
$request = new Request('GET', '/v2/users');
$response = $client->getAuthenticatedClient()->send($request);
$users = json_decode($response->getBody(),true);

foreach ($users as $user) {
    var_dump($user);
}
```